### PR TITLE
Added Nano JSX to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Modules that have been made cross-runtime using Denoify:
 
 - [EVT](https://evt.land)
 - [run-exclusive](https://github.com/garronej/run-exclusive)
+- [Nano JSX](https://github.com/nanojsx/nano)
 
 # Video introduction
 


### PR DESCRIPTION
I have added my project Nano JSX to the "Example of modules using Denoify" section. It is a SSR first, lightweight 1kB JSX library that works on Node and Deno. I have used Denoify to publish the entire code to deno.land/x.