### PR TITLE
add support for rxjs/webSocket in replacer

### DIFF
--- a/src/bin/replacer/rxjs.ts
+++ b/src/bin/replacer/rxjs.ts
@@ -98,7 +98,20 @@ export const replacer: Replacer = async params => {
             ].join("\n")
 
         }
-        default: throw new Error(`Only support import from "${moduleName}" or "${moduleName}/operators"`);
+        case "webSocket": {
+
+            const { target } = parsedImportExportStatement;
+
+            const url = `https://cdn.skypack.dev/rxjs@${version}/webSocket?dts`;
+
+            if (target === undefined) {
+                //NOTE: More certainly useless to import like that
+                return `import "${url}";`;
+            }
+
+            return `import ${target} from "${url}";`;
+        }
+        default: throw new Error(`Only support import from "${moduleName}", "${moduleName}/operators", or "${moduleName}/webSocket`);
     }
 
 

--- a/src/test/replacer.ts
+++ b/src/test/replacer.ts
@@ -71,6 +71,26 @@ const { consumeExecutableReplacer } = consumeExecutableReplacerFactory({
 
     }
 
+    for (const target of ["{ webSocket, WebSocketSubjectConfig }", "* as rxjsWs"]) {
+
+
+        const output = await consumeExecutableReplacer({
+            "parsedImportExportStatement": ParsedImportExportStatement.parse(`import ${target} from "rxjs/webSocket"`) as any,
+            "version": "6.6.2",
+            "destDirPath": "..."
+        });
+
+
+        assert(
+            output
+            ===
+            [
+                `import ${target} from "https://cdn.skypack.dev/rxjs@6.6.2/webSocket?dts";`
+            ].join("\n")
+        );
+
+    }
+
     {
 
         const output = await consumeExecutableReplacer({


### PR DESCRIPTION
use skypack CDN with `X-TypeScript-Types` header support