### PR TITLE
feat: output dir config & remove dep on pkg 'main'

### DIFF
--- a/src/bin/denoify.ts
+++ b/src/bin/denoify.ts
@@ -12,7 +12,7 @@ commanderStatic
     `)
     .option("-p, --project [projectPath]", `Default: './' -- Root path of the project to denoify, target directory is supposed to contain a 'package.json' and 'tsconfig.json'.`)
     .option("--src [srcDirPath]", `Default: '[projectPath]/src' | '[projectPath]/lib' -- Path to the directory containing the source .ts files. If the provided path is not absolute it is assumed relative to [projectPath]`)
-    .option("--out [outputDirPath]", `Default: '<tsconfig.outputDir>/deno_lib' -- Path to the output directory`)
+    .option("--out [outputDirPath]", `Default: '<tsconfig.outDir>/deno_lib' -- Path to the output directory`)
     ;
 
 commanderStatic.parse(process.argv);

--- a/src/bin/denoify.ts
+++ b/src/bin/denoify.ts
@@ -12,6 +12,7 @@ commanderStatic
     `)
     .option("-p, --project [projectPath]", `Default: './' -- Root path of the project to denoify, target directory is supposed to contain a 'package.json' and 'tsconfig.json'.`)
     .option("--src [srcDirPath]", `Default: '[projectPath]/src' | '[projectPath]/lib' -- Path to the directory containing the source .ts files. If the provided path is not absolute it is assumed relative to [projectPath]`)
+    .option("--out [outputDirPath]", `Default: '<tsconfig.outputDir>/deno_lib' -- Path to the output directory`)
     ;
 
 commanderStatic.parse(process.argv);
@@ -20,5 +21,6 @@ const options = commanderStatic.opts();
 
 denoify({
     "projectPath": options.project,
-    "srcDirPath": options.src
+    "srcDirPath": options.src,
+    "denoDirPath": options.out,
 });

--- a/src/bin/denoify.ts
+++ b/src/bin/denoify.ts
@@ -12,7 +12,7 @@ commanderStatic
     `)
     .option("-p, --project [projectPath]", `Default: './' -- Root path of the project to denoify, target directory is supposed to contain a 'package.json' and 'tsconfig.json'.`)
     .option("--src [srcDirPath]", `Default: '[projectPath]/src' | '[projectPath]/lib' -- Path to the directory containing the source .ts files. If the provided path is not absolute it is assumed relative to [projectPath]`)
-    .option("--out [outputDirPath]", `Default: '<tsconfig.outDir>/deno_lib' -- Path to the output directory`)
+    .option("--out [outputDirPath]", `Default: '$(dirname <tsconfig.outDir>)/deno_lib' -- Path to the output directory`)
     ;
 
 commanderStatic.parse(process.argv);


### PR DESCRIPTION
- Add output dir config
- Use warning instead of throw when `mod.ts` cannot be generated. Currently `denoify` requires that package.json `main` should be inside `tsconfig.outDir`. It causes `denoify` cannot work on some projects and there is no workaround.
