### PR TITLE
Fix indexFilePath option

### DIFF
--- a/src/bin/denoify.ts
+++ b/src/bin/denoify.ts
@@ -24,5 +24,5 @@ denoify({
     "projectPath": options.project,
     "srcDirPath": options.src,
     "denoDistPath": options.out,
-    "indexFilePath": options.indexFilePath
+    "indexFilePath": options.index
 });


### PR DESCRIPTION
Hi all,

It seems that the `--index` option is not being parsed properly. When running:

```sh
npx denoify --src denoDist --out deno_dist --index index.ts
```

I receive the following output:

```
...
Denoify did not generate "mod.ts" file because your index wasn't found. You have two options:
1) You may create denoDist/mod.ts it will be denoified and moved to deno_dist.
2) You can also specify where is your index using the denoify.index field in package.js
```


Adding a little logging
```js
...
const options = commanderStatic.opts();
console.log(options);

denoify({
    "projectPath": options.project,
    "srcDirPath": options.src,
    "denoDistPath": options.out,
    "indexFilePath": options.index
});
```

reveals:

```js
{
  project: undefined,
  src: 'denoDist',
  out: 'deno_dist',
  index: 'index.ts'
}
```

so I simply changed the call to the main denoify function to be:
```js
denoify({
    "projectPath": options.project,
    "srcDirPath": options.src,
    "denoDistPath": options.out,
    "indexFilePath": options.index
});
```

Please let me know if there's anything else I can do :)
Dom