### PR TITLE
test(): uncommented tests

### DIFF
--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -2,12 +2,12 @@ import { runSequentially } from "../tools/runSequentially";
 
 runSequentially({
     "scriptsPaths": [
-        "resolveNodeModuleToDenoModule"
-        // "types/parsedImportExportStatement",
-        // "denoifyImportExportStatement",
-        // "denoifySingleFile",
-        // "getInstalledVersionPackageJson",
-        // "replacer",
-        // "parseParams"
+        "resolveNodeModuleToDenoModule",
+        "types/parsedImportExportStatement",
+        "denoifyImportExportStatement",
+        "denoifySingleFile",
+        "getInstalledVersionPackageJson",
+        "replacer",
+        "parseParams"
     ]
 });


### PR DESCRIPTION
I forgot to un-comment the tests when I was isolating the tests for the `config-file` feature

The problem of not being able to detect whether there is any commented test in ci-cd will be addressed when a testing framework will be used for testing