### PR TITLE
rename builtin handlers

### DIFF
--- a/src/lib/builtins/index.ts
+++ b/src/lib/builtins/index.ts
@@ -1,6 +1,6 @@
-import * as __dirname from "./__dirname";
-import * as __filename from "./__filename";
-import * as buffer from "./buffer";
+import * as __dirnameBuiltin from "./__dirname";
+import * as __filenameBuiltin from "./__filename";
+import * as bufferBuiltin from "./buffer";
 
 /**
  * This is how we handle Node builtins
@@ -10,6 +10,6 @@ import * as buffer from "./buffer";
  * - modification: string[] the lines of code to prepend to the source code
  */
 
-const builtins = [__filename, __dirname, buffer];
+const builtins = [__filenameBuiltin, __dirnameBuiltin, bufferBuiltin];
 
 export default builtins;


### PR DESCRIPTION
So, it turns out that naming the builtin handlers after builtins was a mistake 😬 

When I tried to run this on `protobuf-es`, I got the following error:

```
/Users/danrumney/Projects/protobuf-es/node_modules/denoify/lib/builtins/index.js:3
const __dirname = require("./__dirname");
      ^

SyntaxError: Identifier '__dirname' has already been declared
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1176:20)
    at Module._compile (node:internal/modules/cjs/loader:1218:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/danrumney/Projects/protobuf-es/node_modules/denoify/lib/denoifySingleFile.js:6:17)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
```

Good news: it's an easy fix :)