### PR TITLE
Import `node:process` if `process` is used

### DIFF
--- a/src/lib/builtins/index.ts
+++ b/src/lib/builtins/index.ts
@@ -1,6 +1,7 @@
 import * as __dirname from "./__dirname";
 import * as __filename from "./__filename";
 import * as buffer from "./buffer";
+import * as processBuiltin from "./process";
 
 /**
  * This is how we handle Node builtins
@@ -10,6 +11,6 @@ import * as buffer from "./buffer";
  * - modification: string[] the lines of code to prepend to the source code
  */
 
-const builtins = [__filename, __dirname, buffer];
+const builtins = [__filename, __dirname, buffer, processBuiltin];
 
 export default builtins;

--- a/src/lib/builtins/process.ts
+++ b/src/lib/builtins/process.ts
@@ -1,0 +1,5 @@
+const PROCESS_IS_USED = /process\./;
+
+export const test = (sourceCode: string) => PROCESS_IS_USED.test(sourceCode);
+
+export const modification = [`import process from "node:process";`];

--- a/src/lib/denoifySingleFile.ts
+++ b/src/lib/denoifySingleFile.ts
@@ -75,16 +75,6 @@ export function denoifySingleFileFactory(params: {} & ReturnType<typeof denoifyI
             }
         }
 
-        // Handle environment variable access
-        modifiedSourceCode = modifiedSourceCode.replaceAll(
-            /=\s+process.env(?:\.(?<varDot>\w+)|\[(?<q>['"])(?<varBracket>\w+)\k<q>\])/g,
-            `= Deno.env.get('$<varDot>$<varBracket>')`
-        );
-        modifiedSourceCode = modifiedSourceCode.replaceAll(
-            /process.env(?:\.(?<varDot>\w+)|\[(?<q>['"])(?<varBracket>\w+)\k<q>\])\s+=\s+(?<val>[^;]+)/g,
-            `Deno.env.set('$<varDot>$<varBracket>', $<val>)`
-        );
-
         for (const [hash, denoifiedImportExportStatement] of denoifiedImportExportStatementByHash) {
             modifiedSourceCode = modifiedSourceCode.replace(new RegExp(hash, "g"), denoifiedImportExportStatement);
         }

--- a/test/denoifySingleFile.test.ts
+++ b/test/denoifySingleFile.test.ts
@@ -209,7 +209,7 @@ Buffer.from("hello");
         expect(modifiedSourceCode).toBe(expected);
     });
 
-    it("should denoify the source code by adding relevant import statement", async () => {
+    it("should denoify the source code by adding relevant import statement (Buffer.from)", async () => {
         const sourceCode = `
 Buffer.from("hello");
 `;
@@ -248,7 +248,7 @@ Buffer.from("hello");
 
         expect(modifiedSourceCode).toBe(expected);
     });
-    it("should denoify the source code by adding relevant import statement", async () => {
+    it("should denoify the source code by adding relevant import statement (Buffer)", async () => {
         const sourceCode = `
 Buffer`;
 
@@ -324,56 +324,23 @@ Buffer_name
 
         expect(modifiedSourceCode).toBe(expected);
     });
-    it("should access environment variables correctly", async () => {
-        const sourceCode = `const foo = process.env.FOO\nconst bar = process.env['BAR'];`;
 
-        const expected = `const foo = Deno.env.get('FOO')\nconst bar = Deno.env.get('BAR');`;
+    it("should import node:process if process is used", async () => {
+        const sourceCode = `const foo = process.env.FOO;\nconst bar = process.env['BAR'];`;
+
+        const expected = `import process from "node:process";
+const foo = process.env.FOO;
+const bar = process.env['BAR'];`;
 
         const { denoifySingleFile } = denoifySingleFileFactory({
-            "denoifyImportExportStatement": () => {
-                tsafeAssert(false);
+            "denoifyImportExportStatement": async ({ importExportStatement }) => {
+                return importExportStatement;
             }
         });
 
         const modifiedSourceCode = await denoifySingleFile({
             sourceCode,
-            "dirPath": ""
-        });
-
-        expect(modifiedSourceCode).toBe(expected);
-    });
-    it("should set environment variables correctly", async () => {
-        const sourceCode = `process.env.FOO = 'foo';\nprocess.env['BAR'] = 22;`;
-
-        const expected = `Deno.env.set('FOO', 'foo');\nDeno.env.set('BAR', 22);`;
-
-        const { denoifySingleFile } = denoifySingleFileFactory({
-            "denoifyImportExportStatement": () => {
-                tsafeAssert(false);
-            }
-        });
-
-        const modifiedSourceCode = await denoifySingleFile({
-            sourceCode,
-            "dirPath": ""
-        });
-
-        expect(modifiedSourceCode).toBe(expected);
-    });
-    it("should update environment variables correctly", async () => {
-        const sourceCode = `process.env.FOO = process.env['BAR']+1;\nprocess.env['BAR'] = process.env.FOO + 'bar';`;
-
-        const expected = `Deno.env.set('FOO', Deno.env.get('BAR')+1);\nDeno.env.set('BAR', Deno.env.get('FOO') + 'bar');`;
-
-        const { denoifySingleFile } = denoifySingleFileFactory({
-            "denoifyImportExportStatement": () => {
-                tsafeAssert(false);
-            }
-        });
-
-        const modifiedSourceCode = await denoifySingleFile({
-            sourceCode,
-            "dirPath": ""
+            "dirPath": "whatever"
         });
 
         expect(modifiedSourceCode).toBe(expected);


### PR DESCRIPTION
After investigating a different issue, I discovered that `process` is available in Deno if you import `node:process`.

This seems like a much safer and sustainable fix to handling environment variable access.

Fixes #108 